### PR TITLE
Export default IdleTimerManager 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A cross-platform bridge that allows you to enable and disable the screen idle ti
 ## Install
 `npm install react-native-idle-timer@latest --save`
 
+## Configure
+### with RNPM
+`rnpm link react-native-idle-timer`
+
+### Manually
 #### iOS
 1. In the XCode's "Project navigator", right click on your project's Libraries folder ➜ `Add Files to <...>`
 2. Go to `node_modules` ➜ `react-native-idle-timer` ➜ `ios` ➜ select `RNIdleTimer.xcodeproj`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A cross-platform bridge that allows you to enable and disable the screen idle ti
 1. In your React Native javascript code, bring in the native module:
 
   ```javascript
-var IdleTimerManager = require('NativeModules').IdleTimerManager;
+import IdleTimerManager from 'react-native-idle-timer';
   ```
 2. To disable the idle timer on a specific view component:
   

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+var { NativeModules } = require('react-native')
+
+module.exports = NativeModules.IdleTimerManager;

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
     "timer",
     "dim"
   ],
-  "nativePackage": true
+  "nativePackage": true,
+  "main": "index.js"
 }


### PR DESCRIPTION
Simplify usage by exporting IdleTimeManager directly.

Add documentation on how to use with rnpm