### PR TITLE
Change react-native headers for 0.40 compatibility

### DIFF
--- a/ios/RNIdleTimer/IdleTimerManager.h
+++ b/ios/RNIdleTimer/IdleTimerManager.h
@@ -1,5 +1,9 @@
 #import <UIKit/UIKit.h>
+#if __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
+#else
+#import <React/RCTBridgeModule.h>
+#endif
 
 @interface IdleTimerManager : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
This pull request adds compatibility with react-native 0.40 while keeping backwards compatibility with older versions.   
The breaking changes were announced here https://github.com/facebook/react-native/releases/tag/v0.40.0  
Backwards compatibilty solution was founded here https://medium.com/@thisismissem/how-to-upgrade-react-native-modules-in-a-backwards-compatible-manner-a5b5c48d590c#.u4m6ktkex