### PR TITLE
[Android] Remove deprecated override on createJSModules method

### DIFF
--- a/android/src/main/java/com/marcshilling/idletimer/IdleTimerPackage.java
+++ b/android/src/main/java/com/marcshilling/idletimer/IdleTimerPackage.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class IdleTimerPackage implements ReactPackage {
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
@@ -18,7 +19,8 @@ public class IdleTimerPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Deprecated in React Native 0.47.0
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android from RN 0.47](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8). This is backwards compatible!