### PR TITLE
Use react-native version for node_modules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,5 +39,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
I described it with details [here](https://github.com/tinycreative/react-native-intercom/pull/94). Please merge as it's nothing breaking.