### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A cross-platform bridge that allows you to enable and disable the screen idle ti
 
 #### Automatically
 
-`react-native link`
+`react-native link react-native-idle-timer`
 
 #### Manually
 


### PR DESCRIPTION
I suggest narrowing down the link to just react-native-idle-timer so it doesn't perform the link on all of the dependencies. There are scenarios where it will add duplicate references to the android project which will cause it to crash