### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "version": "2.1.6",
   "author": "Marc Shilling (marcshilling)",
+  "license": "MIT",
   "description": "A cross-platform bridge that allows you to enable and disable the screen idle timer in your React Native app",
   "keywords": [
     "react-native",


### PR DESCRIPTION
Add MIT license type to package.json to match LICENSE.md so license type shows up in places like npmjs.com.