### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/react-native-idle-timer.podspec
+++ b/react-native-idle-timer.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/RNIdleTimer/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core. This change is necessary for all native modules on iOS.  Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116