### PR TITLE
feat: tag every call to disable the idle timer and expose static method for non react-native usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,40 +58,43 @@ protected List<ReactPackage> getPackages() {
 
 1. In your React Native javascript code, bring in the native module:
 
-```javascript
-import IdleTimerManager from 'react-native-idle-timer';
-```
+    ```javascript
+    import IdleTimerManager from 'react-native-idle-timer';
+    ```
 
 1. To disable the idle timer on a specific view component:
 
-```javascript
-componentWillMount() {
-  IdleTimerManager.setIdleTimerDisabled(true);
-}
+    ```javascript
+    componentWillMount() {
+      IdleTimerManager.setIdleTimerDisabled(true);
+    }
 
-componentWillUnmount() {
-  IdleTimerManager.setIdleTimerDisabled(false);
-}
-```
+    componentWillUnmount() {
+      IdleTimerManager.setIdleTimerDisabled(false);
+    }
+    ```
 
 1. Sometimes you want to disable the idle timer in multiple places, for example, both parent and child component disable and enable the idle timer on mount and unmoumt respectively. When the child component unmount, you expect the idle timer should still disable. The fact is the idle timer get enabled. Because of that, you need to scope it.
 
-```javascript
-IdleTimerManager.setIdleTimerDisabled(true, "<any name you want>");
+    ```javascript
+    useEffect(() => {
+      IdleTimerManager.setIdleTimerDisabled(true, "<any name you want>");
+      return () => {
+        IdleTimerManager.setIdleTimerDisabled(false, "<any name you want>");
+      }
+    }, []);
+    ```
 
-IdleTimerManager.setIdleTimerDisabled(false, "<any name you want>");
-```
+1. If you have multiple places set the idle time on native side, you will have the previous issue. Because of that, this library provides a centralized way to enable and disable the idle timer
 
-1. If you have multiple places set the idle time on native side, you will have the previous issue. Because of that, this library provide a centralized way to enable and able the idle timer
+    ```java
+    IdleTimerManager.activate(activity, "<any name you want>");
 
-```java
-IdleTimerManager.activate(activity, "<any name you want>");
+    IdleTimerManager.deactivate(activity, "<any name you want>");
+    ```
 
-IdleTimerManager.deactivate(activity, "<any name you want>");
-```
+    ```objectivec
+    [IdleTimerManager activate:@"<any name you want>"];
 
-```objc
-[IdleTimerManager activate:@"<any name you want>"];
-
-[IdleTimerManager deactivate:@"<any name you want>"];
-```
+    [IdleTimerManager deactivate:@"<any name you want>"];
+    ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ protected List<ReactPackage> getPackages() {
 import IdleTimerManager from 'react-native-idle-timer';
 ```
 
-2. To disable the idle timer on a specific view component:
+1. To disable the idle timer on a specific view component:
 
 ```javascript
 componentWillMount() {
@@ -72,4 +72,26 @@ componentWillMount() {
 componentWillUnmount() {
   IdleTimerManager.setIdleTimerDisabled(false);
 }
+```
+
+1. Sometimes you want to disable the idle timer in multiple places, for example, both parent and child component disable and enable the idle timer on mount and unmoumt respectively. When the child component unmount, you expect the idle timer should still disable. The fact is the idle timer get enabled. Because of that, you need to scope it.
+
+```javascript
+IdleTimerManager.setIdleTimerDisabled(true, "<any name you want>");
+
+IdleTimerManager.setIdleTimerDisabled(false, "<any name you want>");
+```
+
+1. If you have multiple places set the idle time on native side, you will have the previous issue. Because of that, this library provide a centralized way to enable and able the idle timer
+
+```java
+IdleTimerManager.activate(activity, "<any name you want>");
+
+IdleTimerManager.deactivate(activity, "<any name you want>");
+```
+
+```objc
+[IdleTimerManager activate:@"<any name you want>"];
+
+[IdleTimerManager deactivate:@"<any name you want>"];
 ```

--- a/README.md
+++ b/README.md
@@ -76,13 +76,28 @@ protected List<ReactPackage> getPackages() {
 
 1. Sometimes you want to disable the idle timer in multiple places, for example, both parent and child component disable and enable the idle timer on mount and unmoumt respectively. When the child component unmount, you expect the idle timer should still disable. The fact is the idle timer get enabled. Because of that, you need to scope it.
 
-    ```javascript
-    useEffect(() => {
-      IdleTimerManager.setIdleTimerDisabled(true, "<any name you want>");
-      return () => {
-        IdleTimerManager.setIdleTimerDisabled(false, "<any name you want>");
-      }
-    }, []);
+    ```jsx
+    function Parent() {
+      useEffect(() => {
+        IdleTimerManager.setIdleTimerDisabled(true, "parent");
+        return () => {
+          IdleTimerManager.setIdleTimerDisabled(false, "parent");
+        }
+      }, []);
+
+      return <Child />
+    }
+
+    function Child() {
+      useEffect(() => {
+        IdleTimerManager.setIdleTimerDisabled(true, "child");
+        return () => {
+          IdleTimerManager.setIdleTimerDisabled(false, "child");
+        }
+      }, []);
+
+      return null;
+    }
     ```
 
 1. If you have multiple places set the idle time on native side, you will have the previous issue. Because of that, this library provides a centralized way to enable and disable the idle timer

--- a/README.md
+++ b/README.md
@@ -56,60 +56,59 @@ protected List<ReactPackage> getPackages() {
 
 ## Usage
 
-1. In your React Native javascript code, bring in the native module:
+### In your React Native javascript code, bring in the native module:
 
-    ```javascript
-    import IdleTimerManager from 'react-native-idle-timer';
-    ```
+```javascript
+import IdleTimerManager from 'react-native-idle-timer';
+```
+<br/>
 
-1. To disable the idle timer on a specific view component:
+### To disable the idle timer while a certain component is mounted:
 
-    ```javascript
-    componentWillMount() {
-      IdleTimerManager.setIdleTimerDisabled(true);
-    }
+Class component
+```javascript
+componentWillMount() {
+  IdleTimerManager.setIdleTimerDisabled(true);
+}
 
-    componentWillUnmount() {
-      IdleTimerManager.setIdleTimerDisabled(false);
-    }
-    ```
+componentWillUnmount() {
+  IdleTimerManager.setIdleTimerDisabled(false);
+}
+```
 
-1. Sometimes you want to disable the idle timer in multiple places, for example, both parent and child component disable and enable the idle timer on mount and unmoumt respectively. When the child component unmount, you expect the idle timer should still disable. The fact is the idle timer get enabled. Because of that, you need to scope it.
 
-    ```jsx
-    function Parent() {
-      useEffect(() => {
-        IdleTimerManager.setIdleTimerDisabled(true, "parent");
-        return () => {
-          IdleTimerManager.setIdleTimerDisabled(false, "parent");
-        }
-      }, []);
+Function component
 
-      return <Child />
-    }
+```javascript
+useEffect(() => {
+  IdleTimerManager.setIdleTimerDisabled(true);
 
-    function Child() {
-      useEffect(() => {
-        IdleTimerManager.setIdleTimerDisabled(true, "child");
-        return () => {
-          IdleTimerManager.setIdleTimerDisabled(false, "child");
-        }
-      }, []);
+  return () => IdleTimerManager.setIdleTimerDisabled(false);
+}, [])
+```
+<br/>
 
-      return null;
-    }
-    ```
+### If you have multiple components that are responsible for interacting with the idle timer, you can pass a tag as the second parameter:
 
-1. If you have multiple places set the idle time on native side, you will have the previous issue. Because of that, this library provides a centralized way to enable and disable the idle timer
+```javascript
+useEffect(() => {
+  IdleTimerManager.setIdleTimerDisabled(true, "video");
 
-    ```java
-    IdleTimerManager.activate(activity, "<any name you want>");
+  return () => IdleTimerManager.setIdleTimerDisabled(false, "video");
+}, [])
+```
+<br/>
 
-    IdleTimerManager.deactivate(activity, "<any name you want>");
-    ```
+### If you need to interact from the native Android or iOS side:
 
-    ```objectivec
-    [IdleTimerManager activate:@"<any name you want>"];
+Android
+```java
+IdleTimerManager.activate(activity, "video");
+IdleTimerManager.deactivate(activity, "video");
+```
 
-    [IdleTimerManager deactivate:@"<any name you want>"];
-    ```
+iOS
+```objectivec
+[IdleTimerManager activate:@"video"];
+[IdleTimerManager deactivate:@"video"];
+```

--- a/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
+++ b/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
@@ -1,19 +1,21 @@
 package com.marcshilling.idletimer;
 
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import java.util.Map;
-import java.util.HashMap;
+
+import java.util.HashSet;
 
 import android.app.Activity;
 import android.view.WindowManager;
 
+import org.jetbrains.annotations.NotNull;
+
 public class IdleTimerManager extends ReactContextBaseJavaModule
 {
     static final String MODULE_NAME = "IdleTimerManager";
+
+    static final HashSet<String> tags = new HashSet();
 
     public IdleTimerManager(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -25,22 +27,30 @@ public class IdleTimerManager extends ReactContextBaseJavaModule
     }
 
     @ReactMethod
-    public void setIdleTimerDisabled(final boolean disabled) {
-
+    public void setIdleTimerDisabled(final boolean disabled, final String tag) {
         final Activity activity = this.getCurrentActivity();
-        if (activity != null) {
-            activity.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    if (disabled) {
-                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                    } else {
-                        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                    }
-                }
+        if (disabled) {
+            activate(activity, tag);
+        } else {
+            deactivate(activity, tag);
+        }
+    }
+
+    public static void activate(@NotNull final Activity activity, final String tag) {
+        if (tags.isEmpty()) {
+            activity.runOnUiThread(() -> {
+                activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             });
         }
+        tags.add((tag == null ? "" : tag));
+    }
 
-
+    public static void deactivate(@NotNull final Activity activity, final String tag) {
+        if (tags.size() == 1 && tags.contains((tag))) {
+            activity.runOnUiThread(() -> {
+                activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            });
+        }
+        tags.remove((tag == null ? "" : tag));
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare namespace RNIdleTimer {
-  function setIdleTimerDisabled(disabled: boolean): void;
+  function setIdleTimerDisabled(disabled: boolean, tag: string | undefined): void;
 }
 export = RNIdleTimer

--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@
 
 var { NativeModules } = require('react-native')
 
-module.exports = NativeModules.IdleTimerManager;
+module.exports.setIdleTimerDisabled = (disabled, tag = "") => {
+  NativeModules.IdleTimerManager.setIdleTimerDisabled(disabled, tag);
+}

--- a/ios/RNIdleTimer/IdleTimerManager.h
+++ b/ios/RNIdleTimer/IdleTimerManager.h
@@ -7,4 +7,7 @@
 
 @interface IdleTimerManager : NSObject <RCTBridgeModule>
 
++ (void)activate:(NSString*)tag;
++ (void)deactivate:(NSString*)tag;
+
 @end

--- a/ios/RNIdleTimer/IdleTimerManager.m
+++ b/ios/RNIdleTimer/IdleTimerManager.m
@@ -1,13 +1,44 @@
 #import "IdleTimerManager.h"
 
+const static NSMutableSet *tags;
+
 @implementation IdleTimerManager
+
++ (void) initialize {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        tags = [NSMutableSet set];
+    });
+}
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(setIdleTimerDisabled:(BOOL)disabled) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [UIApplication sharedApplication].idleTimerDisabled = disabled;
-    });
+RCT_EXPORT_METHOD(setIdleTimerDisabled:(BOOL)disabled tag:(NSString *)tag) {
+    if (disabled) {
+        [IdleTimerManager activate:tag];
+    } else {
+        [IdleTimerManager deactivate:tag];
+    }
+}
+
++ (void)activate:(NSString*)tag {
+    if ([tags count] == 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UIApplication sharedApplication].idleTimerDisabled = YES;
+        });
+    }
+
+    [tags addObject:tag ?: @""];
+}
+
++ (void)deactivate:(NSString*)tag {
+    if ([tags count] == 1 && [tags containsObject:tag]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UIApplication sharedApplication].idleTimerDisabled = NO;
+        });
+    }
+
+    [tags removeObject:tag ?: @""];
 }
 
 @end


### PR DESCRIPTION
expo-keep-awake can tag every call to keep the screen awake and this library does not have capability. Meanwhile, I also expose a static method for non react native code to keep the screen awake in a centralized place 

Android implementation from expo https://github.com/expo/expo/blob/main/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/ExpoKeepAwakeManager.kt

iOS  implementation from expo https://github.com/expo/expo/blob/main/packages/expo-keep-awake/ios/KeepAwakeModule.swift