### PR TITLE
fix for android crash

### DIFF
--- a/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
+++ b/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
@@ -29,10 +29,12 @@ public class IdleTimerManager extends ReactContextBaseJavaModule
     @ReactMethod
     public void setIdleTimerDisabled(final boolean disabled, final String tag) {
         final Activity activity = this.getCurrentActivity();
-        if (disabled) {
-            activate(activity, tag);
-        } else {
-            deactivate(activity, tag);
+        if (activity != null) {
+            if (disabled) {
+                activate(activity, tag);
+            } else {
+                deactivate(activity, tag);
+            }
         }
     }
 
@@ -46,7 +48,7 @@ public class IdleTimerManager extends ReactContextBaseJavaModule
     }
 
     public static void deactivate(@NotNull final Activity activity, final String tag) {
-        if (tags.size() == 1 && tags.contains((tag))) {
+        if (tags.size() == 1 && tags.contains((tag == null ? "" : tag))) {
             activity.runOnUiThread(() -> {
                 activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             });

--- a/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
+++ b/android/src/main/java/com/marcshilling/idletimer/IdleTimerManager.java
@@ -44,15 +44,15 @@ public class IdleTimerManager extends ReactContextBaseJavaModule
                 activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             });
         }
-        tags.add((tag == null ? "" : tag));
+        tags.add(tag == null ? "" : tag);
     }
 
     public static void deactivate(@NotNull final Activity activity, final String tag) {
-        if (tags.size() == 1 && tags.contains((tag == null ? "" : tag))) {
+        if (tags.size() == 1 && tags.contains(tag == null ? "" : tag)) {
             activity.runOnUiThread(() -> {
                 activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             });
         }
-        tags.remove((tag == null ? "" : tag));
+        tags.remove(tag == null ? "" : tag);
     }
 }

--- a/ios/RNIdleTimer/IdleTimerManager.m
+++ b/ios/RNIdleTimer/IdleTimerManager.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(setIdleTimerDisabled:(BOOL)disabled tag:(NSString *)tag) {
 }
 
 + (void)deactivate:(NSString*)tag {
-    if ([tags count] == 1 && [tags containsObject:tag]) {
+    if ([tags count] == 1 && [tags containsObject:tag ?: @""]) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [UIApplication sharedApplication].idleTimerDisabled = NO;
         });


### PR DESCRIPTION
For some reason, a recent commit removed the check for a null return from `getCurrentActivity()`. But since `getCurrentActivity()` might return null, the app will crash with a NullPointerException.

This restores the null check.

It also fixes inconsistent handling of null `tag` argument in both iOS and Android. This does not affect usage from JS because the JS interface will not pass null to that argument; however other native code could still call these methods and pass null for `tag`.

Fixes: #32