### PR TITLE
Chore/update android build config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.4'
+            classpath 'com.android.tools.build:gradle:7.4.2'
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -56,7 +56,7 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This PR updates the Android build configuration to fix build failures with React Native 0.82.0 and improve compatibility with modern Android tooling.

  ## Problem

  When using this library with React Native 0.82.0, the Android build fails because JCenter has been deprecated and shut down. The build system can no longer resolve dependencies from `jcenter()`.

  ## Changes

  1. **Replace jcenter() with mavenCentral()**: JCenter was officially shut down in 2022. This change migrates to `mavenCentral()`, which is the recommended Maven repository for Android dependencies.

  2. **Update Android Gradle plugin**: Upgrades the Gradle plugin from `3.5.4` to `7.4.2` for better compatibility with modern Android build tools and recent React Native versions.